### PR TITLE
Rename mbps to MB/s

### DIFF
--- a/src/components/ui/DownloadProgressComponent.tsx
+++ b/src/components/ui/DownloadProgressComponent.tsx
@@ -20,7 +20,7 @@ const LinearProgressWithLabel = (props: any) => (
       <LinearProgress variant="determinate" {...props} />
     </Box>
     <Box style={{ textAlign: 'right' }} minWidth={140}>
-      <Typography variant="body2" color="textSecondary">{Math.round(props.value)}% at {props.downloadspeed} Mbps</Typography>
+      <Typography variant="body2" color="textSecondary">{Math.round(props.value)}% at {props.downloadspeed} MB/s</Typography>
     </Box>
   </Box>
 );

--- a/src/service/HTTPService.ts
+++ b/src/service/HTTPService.ts
@@ -58,7 +58,7 @@ export const httpRequestWithProgress = async (url: string, destPath?: string) =>
     chunks.push(value);
     receivedLength += value.length;
     const mbps = receivedLength / (1024 * 1024);
-    downloadSpeed = Date.now() - startTime === 0 ? downloadSpeed : MB/s / ((Date.now() - startTime) / 1000);
+    downloadSpeed = Date.now() - startTime === 0 ? downloadSpeed : mbps / ((Date.now() - startTime) / 1000);
     const currentTimestamp = +new Date();
 
     progressEvent.addEventListener('progress-cancel', () => {

--- a/src/service/HTTPService.ts
+++ b/src/service/HTTPService.ts
@@ -58,7 +58,7 @@ export const httpRequestWithProgress = async (url: string, destPath?: string) =>
     chunks.push(value);
     receivedLength += value.length;
     const mbps = receivedLength / (1024 * 1024);
-    downloadSpeed = Date.now() - startTime === 0 ? downloadSpeed : mbps / ((Date.now() - startTime) / 1000);
+    downloadSpeed = Date.now() - startTime === 0 ? downloadSpeed : MB/s / ((Date.now() - startTime) / 1000);
     const currentTimestamp = +new Date();
 
     progressEvent.addEventListener('progress-cancel', () => {


### PR DESCRIPTION
Made the download seem much slower than it actually was. Uses the correct term MB/s for megabytes instead of mbps which stands for megabits.

Not a huge change but it was kinda bugging me personally