### PR TITLE
Yuzu portable

### DIFF
--- a/src/containers/FeaturesContainer.tsx
+++ b/src/containers/FeaturesContainer.tsx
@@ -239,7 +239,7 @@ const FeaturesContainer = ({
           <AppBar style={{marginTop: 20}} position="static">
             <Box display="flex" alignItems="center" justifyContent="space-between" paddingRight="12px">
               <Tabs value={tabIndex} onChange={(_, i) => setTabIndex(i)} aria-label="simple tabs example">
-                <Tab disabled={emulator === "yuzu"} label={`Shaders ${emulator === "yuzu" ? '(not ready yet)': ''}`} />
+                <Tab wrapped={emulator === "yuzu"} disabled={emulator === "yuzu"} label={`OpenGL Shaders ${emulator === "yuzu" ? '(not ready yet)': ''}`} />
                 <Tab label="Saves"/>
                 <Tab label="Mods"/>
               </Tabs>

--- a/src/containers/YuzuContainer.tsx
+++ b/src/containers/YuzuContainer.tsx
@@ -2,11 +2,12 @@ import * as React from "react";
 import { IEmusakGame, IEmusakMod, IEmusakSaves } from "../types";
 import FeaturesContainer from "./FeaturesContainer";
 import { downloadSave } from "../service/shared/saves";
-import { Box, CircularProgress } from "@material-ui/core";
+import { Box, CircularProgress, Divider } from "@material-ui/core";
 import electron from "electron";
-import { getYuzuGames, installFirmware, installKeysToYuzu, installMod, isValidFileSystem } from "../service/yuzu/system";
+import { addYuzuFolder, getYuzuGames, installFirmware, installKeysToYuzu, installMod, isValidFileSystem } from "../service/yuzu/system";
 import { useEffect } from "react";
 import Swal from "sweetalert2";
+import EmulatorHeaderComponent from "../components/EmulatorHeaderComponent";
 
 interface IRyujinxContainerProps {
   threshold: number;
@@ -28,7 +29,7 @@ const YuzuContainer = ({threshold, firmwareVersion, emusakSaves, emusakMods}: IR
       if (!isValidFS) {
         Swal.fire({
           icon: 'error',
-          text: 'Cannot find a valid filesystem for yuzu. You need to run yuzu one time to let it create required folders on your disk. Please note emusak does not support portable mode for yuzu at the moment. Once you ran yuzu, please use the reload button near the "Filter game list" input'
+          text: 'Cannot find a valid filesystem for yuzu. You need to run yuzu one time to let it create required folders on your disk. Once you ran yuzu, please use the reload button near the "Filter game list" input. If you are using yuzu with portable mode, use the "Add yuzu folder" above.'
         })
         return false;
       }
@@ -51,6 +52,14 @@ const YuzuContainer = ({threshold, firmwareVersion, emusakSaves, emusakMods}: IR
 
   return (
     <Box p={3}>
+      <EmulatorHeaderComponent
+        threshold={threshold}
+        onFolderAdd={addYuzuFolder}
+        emulator="yuzu"
+      />
+      <br/>
+      <Divider/>
+      <br/>
       {
         (isAppReady)
           ? (

--- a/src/service/yuzu/system.ts
+++ b/src/service/yuzu/system.ts
@@ -11,6 +11,16 @@ import Zip from "adm-zip";
 const getYuzuPath = (config: IEmusakEmulatorConfig, ...paths: string[]) => {
 
   if (!(process.platform === "win32")) {
+    /**
+     * If user installed yuzu with snap on ubuntu, path in located in ~/snap/yuzu
+     */
+    const home = electron.remote.app.getPath('home');
+    const installedWithSnap = fs.existsSync(path.resolve(home, 'snap', 'yuzu', 'common', '.local', 'share', 'yuzu'));
+
+    if (installedWithSnap) {
+      return path.resolve(home, 'snap', 'yuzu', 'common', '.local', 'share', 'yuzu', ...paths);
+    }
+
     return path.resolve(electron.remote.app.getPath('home'), '.local', 'share', 'yuzu', ...paths);
   }
 
@@ -67,6 +77,11 @@ export const getYuzuGames = async () => {
 
   if (!(process.platform === "win32")) {
     const loadPath = getYuzuPath(null, 'load');
+
+    if (!fs.existsSync(loadPath)) {
+      return [];
+    }
+
     const dirents = await readDir(loadPath);
     const games = dirents.filter(d => d.isDirectory()).map(d => d.name.trim().toUpperCase());
 

--- a/src/storage/yuzu.ts
+++ b/src/storage/yuzu.ts
@@ -1,0 +1,57 @@
+import { IEmulatorStorageInterface, IYuzuConfig } from "../types";
+import { isRyujinxPortableMode } from "../service/Ryujinx/system";
+import * as fs from "fs/promises";
+import Swal from "sweetalert2";
+
+class YuzuModel implements IEmulatorStorageInterface {
+  // Localstorage identifier to store ryu config
+  protected readonly LS_DIRECTORIES_KEY = "yuzu-dir"
+
+  public async getDirectories(): Promise<IYuzuConfig[]> {
+    const d = localStorage.getItem(this.LS_DIRECTORIES_KEY);
+    let directories = d ? JSON.parse(d) : [];
+
+    // Check if directories still exists
+    const paths: string[] = directories.map((d: IYuzuConfig) => d.path);
+    const results = await Promise.all(paths.map(async path => {
+      const exists = await fs.stat(path).catch(() => false);
+      if (!exists) {
+        localStorage.removeItem(this.LS_DIRECTORIES_KEY);
+        await Swal.fire({
+          icon: 'error',
+          title: 'Configuration cleared',
+          text: `Path: ${path} does not exists anymore, so emusak cleared configuration. You must add again all your ryujinx instances using "Add Ryujinx folder" button again.`
+        });
+        return false;
+      }
+
+      return true;
+    }));
+
+    if (results.includes(false)) {
+      return this.getDirectories();
+    }
+
+    return directories;
+  }
+
+  public async addDirectory(conf: IYuzuConfig): Promise<void> {
+    const directories = await this.getDirectories();
+
+    if (!directories.map(d => d.path).includes(conf.path)) {
+      directories.push(conf);
+      localStorage.setItem(this.LS_DIRECTORIES_KEY, JSON.stringify(directories));
+    }
+  }
+
+  public async deleteDirectory(conf: IYuzuConfig): Promise<boolean> {
+    let directories = await this.getDirectories();
+    directories = directories.filter(d => d.path !== conf.path);
+    localStorage.setItem(this.LS_DIRECTORIES_KEY, JSON.stringify(directories));
+
+    return true;
+  }
+}
+
+const singleton = new YuzuModel();
+export default singleton;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,11 @@ export interface IRyujinxConfig {
   path: string;
 }
 
+export interface IYuzuConfig {
+  isPortable: boolean;
+  path: string;
+}
+
 export interface IEmusakGame {
   id: string;
   shadersCount: number;


### PR DESCRIPTION
- [x] Fix a crash on linux when yuzu was not installed
- [x] Detecting yuzu path when installed with snap package manager on debian (ubuntu, popos, ...)
- [x] "Shaders" tab has been renamed to "OpenGL shaders"
- [x] mbps speed has been replaced by "MB/s"
- [ ] Add the ability to use yuzu portable