### PR TITLE
Rename portable artifact to include "portable" in the name

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -23,7 +23,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14
-      - run: yarn install
+      - run: npm config rm proxy && npm config rm https-proxy
+        name: "Remove NPM / Yarn proxies"
+      - run: yarn install --frozen-lockfile --network-timeout 1000000
         name: Install NPM dependencies
       - run: node ./src/commands/dumpTinFoil.js
         name: Dump title ids from tinfoil DB

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -3,8 +3,8 @@ name: Build artifacts
 on:
   push:
     branches:
-      - emusak-v2
       - main
+      - ci
     paths:
       - package.json
 
@@ -29,7 +29,9 @@ jobs:
         name: Dump title ids from tinfoil DB
       - run: node ./src/commands/dumpEshopData.js
         name: Dump eshop data
-      - run: npm run publish
+      - run: npm run publish-dry-run
+        name: Packaging app
+      - run: npm run publish-from-dry-run
         name: Publish github artifacts
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -33,9 +33,12 @@ jobs:
         name: Dump eshop data
       - run: npm run publish-dry-run
         name: Packaging app
+        env:
+          USE_HARD_LINKS: false
       - run: npm run publish-from-dry-run
         name: Publish github artifacts
         env:
           GITHUB_TOKEN: ${{ github.token }}
           EMUSAK_CDN: ${{ secrets.EMUSAK_CDN }}
           EMUSAK_URL: ${{ secrets.EMUSAK_URL }}
+          USE_HARD_LINKS: false

--- a/forge.config.js
+++ b/forge.config.js
@@ -26,6 +26,12 @@ module.exports = {
       ]
     },
     {
+      "name": "@electron-forge/maker-squirrel",
+      "config": {
+        "name": "emusak_ui"
+      }
+    },
+    {
       "name": "@electron-forge/maker-deb",
       "config": {}
     },

--- a/forge.config.js
+++ b/forge.config.js
@@ -62,10 +62,10 @@ module.exports = {
   "hooks": {
     "postMake": async (_, makeResults) => {
       const portablePath = makeResults.map(b => b.artifacts).flat().find(i => i.includes(".zip") && i.includes("win32"));
-      const filename = path.basename(portablePath);
 
       try {
         if (portablePath) {
+          const filename = path.basename(portablePath);
           await fs.move(portablePath, portablePath.replace(filename, "EmuSAK-win32-x64-2.0.0-portable.zip"))
         }
       } catch(e) {
@@ -76,9 +76,12 @@ module.exports = {
         ...r,
         ...{
           artifacts:
-            r.artifacts.map(fullPath => fullPath.includes(".zip") && fullPath.includes("win32")
-              ? fullPath.replace(filename, "EmuSAK-win32-x64-2.0.0-portable.zip")
-              : fullPath)
+            r.artifacts.map(fullPath => {
+              const filename = path.basename(fullPath);
+              return fullPath.includes(".zip") && fullPath.includes("win32")
+                ? fullPath.replace(filename, "EmuSAK-win32-x64-2.0.0-portable.zip")
+                : fullPath
+            })
         }
       }))
     }

--- a/forge.config.js
+++ b/forge.config.js
@@ -71,6 +71,7 @@ module.exports = {
 
       if (portablePath) {
         const filename = path.basename(portablePath);
+        console.log({ filename })
         await fs.move(portablePath, portablePath.replace(filename, "EmuSAK-win32-x64-2.0.0-portable.zip"))
       }
     }

--- a/forge.config.js
+++ b/forge.config.js
@@ -69,10 +69,14 @@ module.exports = {
     "postMake": async (_, artifacts) => {
       const portablePath = artifacts.map(b => b.artifacts).flat().find(i => i.includes(".zip") && i.includes("win32"));
 
-      if (portablePath) {
-        const filename = path.basename(portablePath);
-        console.log({ filename })
-        await fs.move(portablePath, portablePath.replace(filename, "EmuSAK-win32-x64-2.0.0-portable.zip"))
+      try {
+        if (portablePath) {
+          const filename = path.basename(portablePath);
+          console.log({ filename })
+          await fs.move(portablePath, portablePath.replace(filename, "EmuSAK-win32-x64-2.0.0-portable.zip"))
+        }
+      } catch(e) {
+
       }
     }
   }

--- a/forge.config.js
+++ b/forge.config.js
@@ -20,6 +20,12 @@ module.exports = {
   ],
   "makers": [
     {
+      "name": "@electron-forge/maker-squirrel",
+      "config": {
+        "name": "emusak_ui"
+      }
+    },
+    {
       "name": "@electron-forge/maker-zip",
       "platforms": [
         "win32"

--- a/forge.config.js
+++ b/forge.config.js
@@ -26,12 +26,6 @@ module.exports = {
       ]
     },
     {
-      "name": "@electron-forge/maker-squirrel",
-      "config": {
-        "name": "emusak_ui"
-      }
-    },
-    {
       "name": "@electron-forge/maker-deb",
       "config": {}
     },
@@ -67,12 +61,13 @@ module.exports = {
   ],
   "hooks": {
     "postMake": async (_, makeResults) => {
+      const version = makeResults[0].packageJSON.version;
       const portablePath = makeResults.map(b => b.artifacts).flat().find(i => i.includes(".zip") && i.includes("win32"));
 
       try {
         if (portablePath) {
           const filename = path.basename(portablePath);
-          await fs.move(portablePath, portablePath.replace(filename, "EmuSAK-win32-x64-2.0.0-portable.zip"))
+          await fs.move(portablePath, portablePath.replace(filename, `EmuSAK-win32-x64-${version}-portable.zip`))
         }
       } catch(e) {
         // fs.move is launched twice, first for dry run and second time by make from dry-run causing an exception, so ignore and assume it exists
@@ -85,7 +80,7 @@ module.exports = {
             r.artifacts.map(fullPath => {
               const filename = path.basename(fullPath);
               return fullPath.includes(".zip") && fullPath.includes("win32")
-                ? fullPath.replace(filename, "EmuSAK-win32-x64-2.0.0-portable.zip")
+                ? fullPath.replace(filename, `EmuSAK-win32-x64-${version}-portable.zip`)
                 : fullPath
             })
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "EmuSAK",
   "productName": "EmuSAK",
   "version": "2.0.1",
-  "description": "This is a tool to manage your switch emulators, such as downloading saves or mods",
+  "description": "This is a tool to manage your switch emulators, such as downloading saves or mods.",
   "repository": "https://github.com/CapitaineJSparrow/emusak-ui",
   "main": ".webpack/main",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "cross-env NODE_ENV=development electron-forge start",
     "package": "electron-forge package",
     "make": "electron-forge make",
-    "publish": "electron-forge publish",
+    "publish-dry-run": "electron-forge publish --dry-run\n",
+    "publish-from-dry-run": "electron-forge publish",
     "lint": "eslint --ext .ts,.tsx .",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "EmuSAK",
   "productName": "EmuSAK",
   "version": "2.0.1",
-  "description": "This is a tool to manage your switch emulators, such as downloading saves or mods.",
+  "description": "This is a tool to manage your switch emulators, such as downloading saves or mods",
   "repository": "https://github.com/CapitaineJSparrow/emusak-ui",
   "main": ".webpack/main",
   "scripts": {


### PR DESCRIPTION
* Make runs more consistant (no more errors due to timeout on windows )
* Rename zip artifact to `EmuSAK-win32-x64-2.0.0-portable.zip`
* Speed up `yarn install` by using `--frozen-lockfile` (supposed to be the yarn alternative to `npm ci`)