### PR TITLE
CLI flag to use the native menu bar

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,11 +88,13 @@ if (handleStartupEvent()) {
   process.exit(0);
 }
 
+const shouldUseNativeMenuBar = app.commandLine.hasSwitch("native-menu-bar");
+
 const createWindow = (): void => {
   // Create the browser window.
   mainWindow = new BrowserWindow({
     resizable: true,
-    autoHideMenuBar: true,
+    autoHideMenuBar: !shouldUseNativeMenuBar,
     show: false,
     frame: false,
     minHeight: 680,
@@ -104,6 +106,11 @@ const createWindow = (): void => {
   });
 
   makeIpcRoutes(mainWindow);
+
+  mainWindow.webContents.on("dom-ready", () => {
+    console.log("SENDING EVENT: native-menu-bar");
+    mainWindow.webContents.send("native-menu-bar", shouldUseNativeMenuBar);
+  });
 
   mainWindow.webContents.on("did-finish-load", function () {
     const displays = screen.getAllDisplays();

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,11 +107,6 @@ const createWindow = (): void => {
 
   makeIpcRoutes(mainWindow);
 
-  mainWindow.webContents.on("dom-ready", () => {
-    console.log("SENDING EVENT: native-menu-bar");
-    mainWindow.webContents.send("native-menu-bar", shouldUseNativeMenuBar);
-  });
-
   mainWindow.webContents.on("did-finish-load", function () {
     const displays = screen.getAllDisplays();
     const display = displays.find((d) => d.bounds.x !== 0 || d.bounds.y !== 0) || displays[0];
@@ -156,7 +151,8 @@ const createWindow = (): void => {
   });
 
   // and load the index.html of the app.
-  mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+  const url = MAIN_WINDOW_WEBPACK_ENTRY + `?useNativeMenuBar=${shouldUseNativeMenuBar}`;
+  mainWindow.loadURL(url);
 
   let cspHeader = "default-src 'self' https://fonts.googleapis.com/ https://fonts.gstatic.com/ 'unsafe-inline'; img-src 'self' data: https://*;";
 

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -70,9 +70,11 @@ use(initReactI18next)
 export const LANGUAGES = Object.keys(resources);
 
 const App = () => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const shouldUseNativeMenuBar = searchParams.get("useNativeMenuBar");
+
   const [isAppInitialized, bootstrapAppAction] = useStore(state => [state.isAppInitialized, state.bootstrapAppAction]);
   const [downloadState, setDownloadState] = useState(null);
-  const [shouldUseNativeMenuBar, setShouldUseNativeMenuBar] = useState(false);
 
   // Hack, due to tree checking, if Swal is not present the theme is not applied for further calls, need better solution
   // eslint-disable-next-line no-constant-condition
@@ -82,56 +84,50 @@ const App = () => {
 
   const onUpdateAvailable = () => setDownloadState("downloading");
   const onUpdateDownloaded = () => () => setDownloadState("downloaded");
-  const onNativeMenuBar = () => (useNativeBar: boolean) => {
-    console.log("onNativeMenuBar");
-    setShouldUseNativeMenuBar(useNativeBar);
-  };
 
   useEffect(() => {
     bootstrapAppAction();
     ipcRenderer.on("update-available", onUpdateAvailable);
     ipcRenderer.on("update-downloaded", onUpdateDownloaded);
-    ipcRenderer.on("native-menu-bar", onNativeMenuBar);
     const t = setInterval(() => ipcRenderer.invoke("check-status").then(r => r ? setDownloadState("downloaded") : undefined),5000);
 
     return () => {
       ipcRenderer.removeListener("update-available", onUpdateAvailable);
       ipcRenderer.removeListener("update-downloaded", onUpdateDownloaded);
-      ipcRenderer.removeListener("native-menu-bar", onNativeMenuBar);
       clearInterval(t);
     };
   }, []);
 
   return (
-    <HashRouter>
-      <ThemeProvider theme={darkTheme}>
-        <CssBaseline>
-          {!shouldUseNativeMenuBar && (<TitleBarComponent />)}
+    <ThemeProvider theme={darkTheme}>
+      <CssBaseline>
+        {!shouldUseNativeMenuBar && (<TitleBarComponent />)}
 
-          <NavBarComponent />
-          <AlertComponent />
-          <DownloadManagerComponent />
-          <DownloadSaveComponent />
-          <DownloadModComponent />
-          <UpdateComponent state={downloadState} />
-          { !isAppInitialized
-            ? <BootstrapComponent />
-            : (
-              <Routes>
-                <Route path="/" element={<RootComponent />} />
-                <Route path="/detail" element={(<GameDetailComponent />)} />
-              </Routes>
-            )
-          }
-          <TOSComponent />
-        </CssBaseline>
-      </ThemeProvider>
-    </HashRouter>
+        <NavBarComponent />
+        <AlertComponent />
+        <DownloadManagerComponent />
+        <DownloadSaveComponent />
+        <DownloadModComponent />
+        <UpdateComponent state={downloadState} />
+        { !isAppInitialized
+          ? <BootstrapComponent />
+          : (
+            <Routes>
+              <Route path="/" element={<RootComponent />} />
+              <Route path="/detail" element={(<GameDetailComponent />)} />
+            </Routes>
+          )
+        }
+        <TOSComponent />
+      </CssBaseline>
+    </ThemeProvider>
   );
 };
 
 ReactDOM.render(
-  <App />,
+  <HashRouter>
+    <App />
+  </HashRouter>,
   document.querySelector("#app")
 );
 

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -73,6 +73,11 @@ const App = () => {
   const searchParams = new URLSearchParams(window.location.search);
   const shouldUseNativeMenuBar = searchParams.get("useNativeMenuBar");
 
+  if (shouldUseNativeMenuBar) {
+    // Set the native class when using the native bar for css
+    document.querySelector("body").classList.add("native");
+  }
+
   const [isAppInitialized, bootstrapAppAction] = useStore(state => [state.isAppInitialized, state.bootstrapAppAction]);
   const [downloadState, setDownloadState] = useState(null);
 

--- a/src/renderer/components/TitleBarComponent/titleBar.css
+++ b/src/renderer/components/TitleBarComponent/titleBar.css
@@ -3,7 +3,7 @@
   --title-bar-buttons-width: 185px;
 }
 
-body {
+body:not(.native) {
   padding-top: var(--title-bar-height)
 }
 


### PR DESCRIPTION
Using the following command for running/debugging:

`ELECTRON_ENABLE_LOGGING=1 npx cross-env NODE_ENV=development electron-forge start -- --native-menu-bar`

Native window controls enabled (I do not display window controls on my system):

![image](https://user-images.githubusercontent.com/34498340/169436242-c184fac8-284b-4c6f-aa63-a0d67d84b2af.png)